### PR TITLE
Various performance optimizations on entity mutations

### DIFF
--- a/__tests__/Entity.test.js
+++ b/__tests__/Entity.test.js
@@ -5,7 +5,7 @@ describe('Entities', () => {
   test('should add an entity to world', () => {
     const world = World({ maxEntities: 10 })
     const eid = world.addEntity()
-    expect(eid).toBe(1)
+    expect(eid).toBe(0)
     expect(world.entityCount()).toBe(1)
     expect(world.registry.entities[0][eid]).toBe(0)
   })
@@ -13,11 +13,11 @@ describe('Entities', () => {
   test('should add an recycled EID entity to world', () => {
     const world = World({ maxEntities: 10 })
     const eid = world.addEntity()
-    expect(eid).toBe(1)
+    expect(eid).toBe(0)
     world.removeEntity(eid)
     world.step()
     const eid2 = world.addEntity()
-    expect(eid2).toBe(1)
+    expect(eid2).toBe(0)
     expect(world.entityCount()).toBe(1)
     expect(world.registry.entities[0][eid]).toBe(0)
   })

--- a/src/Component.js
+++ b/src/Component.js
@@ -255,12 +255,11 @@ export const Component = (config, registry, DataManager) => {
    * world.removeAllComponent(eid, true) // All components Removed
    *
    * @memberof module:World
-   * @param {uint32} eid        - Entity id.
-   * @param {boolean} immediate - Remove immediately. If false, defer until end of tick.
+   * @param {uint32} eid - Entity id.
    */
-  const removeAllComponents = (eid, immediate = false) => {
+  const removeAllComponents = eid => {
     Object.keys(components).forEach(name => {
-      removeComponent(name, eid, immediate)
+      removeComponent(name, eid)
     })
   }
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -50,7 +50,10 @@ export const Component = (config, registry, DataManager) => {
    */
   const registerComponent = (name, schema) => {
     if (Object.keys(components).length + 1 > config.maxComponentTypes) {
-      throw new Error(`❌ Can not register component '${name}'. Max components '${config.maxComponentTypes}' reached.`)
+      throw new Error(
+        `❌ Can not register component '${name}'. ` +
+          `Max components '${config.maxComponentTypes}' reached.`
+      )
     }
     components[name] = DataManager(config.maxEntities, schema)
     components[name].name = name
@@ -63,7 +66,7 @@ export const Component = (config, registry, DataManager) => {
    * @param {string} name
    * @private
    */
-  const getComponentManager = (name) => {
+  const getComponentManager = name => {
     if (components[name] === undefined) {
       throw new Error(`❌ Component '${name}' is not registered.`)
     }
@@ -104,10 +107,9 @@ export const Component = (config, registry, DataManager) => {
    * @param {boolean} reset - Zero out the component values.
    */
   const addComponent = (name, eid, values = {}, reset = true) => {
-    const componentManager = getComponentManager(name)
-
     if (hasComponent(name, eid)) return
 
+    const componentManager = getComponentManager(name)
     const { _generationId, _bitflag } = componentManager
 
     // Add bitflag to entity bitmask
@@ -122,7 +124,11 @@ export const Component = (config, registry, DataManager) => {
     // Add to systems that match the entity bitmask
     for (const s in systems) {
       const system = systems[s]
-      if (system.components.length && system.checkComponent(componentManager) && system.check(eid)) {
+      if (
+        system.components.length &&
+        system.checkComponent(componentManager) &&
+        system.check(eid)
+      ) {
         system.add(eid)
       }
     }
@@ -130,27 +136,37 @@ export const Component = (config, registry, DataManager) => {
 
   /**
    * Internal remove component. Actually removes the component.
-   *
-   * @param {string} name
-   * @param {uint32} eid
    * @private
    */
-  const _removeComponent = (name, eid) => {
-    const componentManager = getComponentManager(name)
-    const { _generationId, _bitflag } = componentManager
+  const commitComponentRemovals = () => {
+    if (deferredComponentRemovals.length === 0) return
 
-    if (!(entities[_generationId][eid] & _bitflag)) return
+    for (let i = 0; i < deferredComponentRemovals.length; i += 2) {
+      const name = deferredComponentRemovals[i]
+      const eid = deferredComponentRemovals[i + 1]
 
-    // Remove flag from entity bitmask
-    entities[_generationId][eid] &= ~_bitflag
+      const componentManager = getComponentManager(name)
+      const { _generationId, _bitflag } = componentManager
 
-    // Remove from systems that no longer match the entity bitmask
-    for (const s in systems) {
-      const system = systems[s]
-      if (system.components.length && system.checkComponent(componentManager) && !system.check(eid)) {
-        system.remove(eid)
+      if (!(entities[_generationId][eid] & _bitflag)) return
+
+      // Remove flag from entity bitmask
+      entities[_generationId][eid] &= ~_bitflag
+
+      // Remove from systems that no longer match the entity bitmask
+      for (const s in systems) {
+        const system = systems[s]
+        if (
+          system.components.length &&
+          system.checkComponent(componentManager) &&
+          !system.check(eid)
+        ) {
+          system.remove(eid)
+        }
       }
     }
+
+    deferredComponentRemovals.length = 0
   }
 
   /**
@@ -193,7 +209,7 @@ export const Component = (config, registry, DataManager) => {
    * @param {uint32} eid        - Entity id.
    */
   const removeComponent = (name, eid) => {
-    deferredComponentRemovals.push(() => _removeComponent(name, eid))
+    deferredComponentRemovals.push(name, eid)
   }
 
   /**
@@ -284,6 +300,6 @@ export const Component = (config, registry, DataManager) => {
     removeComponent,
     removeAllComponents,
     hasComponent,
-    deferredComponentRemovals
+    commitComponentRemovals
   }
 }

--- a/src/Config.js
+++ b/src/Config.js
@@ -6,6 +6,7 @@ export const Config = ({
 }) => ({
   maxEntities,
   maxComponentTypes,
+  maxGenerations: Math.ceil(maxComponentTypes / 32),
   tickRate,
   devtools
 })

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -39,12 +39,12 @@ export const Entity = (config, registry) => {
    * @returns {uint32} The entity id.
    */
   const addEntity = () => {
-    if (entityCount() + 1 > config.maxEntities) {
+    if (_entityCount > config.maxEntities) {
       console.warn('❌ Could not add entity, maximum number of entities reached.')
       return
     }
 
-    const eid = removed.length ? removed.shift() : _entityCount
+    const eid = removed.length > 0 ? removed.pop() : _entityCount
     _entityCount++
     entities.forEach(typedArray => { typedArray[eid] = 0 })
     enabledEntities[eid] = 1

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -40,7 +40,6 @@ export const Entity = (config, registry) => {
     }
 
     const eid = removed.length > 0 ? removed.pop() : entityCursor++
-    for (let arr of entities) arr[eid] = 0
     enabledEntities[eid] = 1
     return eid
   }

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -3,12 +3,7 @@ export const Entity = (config, registry) => {
   const removed = []
   const deferredEntityRemovals = []
   const enabledEntities = new Uint8Array(config.maxEntities)
-
-  /**
-   * Count of entities in this world
-   * @private
-   */
-  let _entityCount = 1
+  let entityCursor = 0
 
   /**
    * Get the count of entities currently in the world.
@@ -23,7 +18,7 @@ export const Entity = (config, registry) => {
    *
    * @memberof module:World
    */
-  const entityCount = () => _entityCount - 1
+  const entityCount = () => entityCursor - removed.length
 
   /**
    * Add a new entity to the world.
@@ -39,38 +34,42 @@ export const Entity = (config, registry) => {
    * @returns {uint32} The entity id.
    */
   const addEntity = () => {
-    if (_entityCount > config.maxEntities) {
+    if (entityCursor >= config.maxEntities) {
       console.warn('❌ Could not add entity, maximum number of entities reached.')
       return
     }
 
-    const eid = removed.length > 0 ? removed.pop() : _entityCount
-    _entityCount++
-    entities.forEach(typedArray => { typedArray[eid] = 0 })
+    const eid = removed.length > 0 ? removed.pop() : entityCursor++
+    for (let arr of entities) arr[eid] = 0
     enabledEntities[eid] = 1
     return eid
   }
 
   /**
    * Internal remove function
-   * @param {uint32} eid
-   * @private true
+   * @private
    */
-  const _removeEntity = eid => {
-    // Check if entity is already removed
-    if (enabledEntities[eid] === 0) return
+  const commitEntityRemovals = () => {
+    if (deferredEntityRemovals.length === 0) return
 
-    // Remove entity from all systems
-    for (const s in systems) {
-      const system = systems[s]
-      system.remove(eid)
+    for (let eid of deferredEntityRemovals) {
+      // Check if entity is already removed
+      if (enabledEntities[eid] === 0) continue
+
+      // Remove entity from all systems
+      for (const s in systems) {
+        systems[s].remove(eid)
+      }
+
+      // Free the entity
+      removed.push(eid)
+      enabledEntities[eid] = 0
+
+      // Clear component bitmasks
+      for (let arr of entities) arr[eid] = 0
     }
-    removed.push(eid)
-    _entityCount--
-    enabledEntities[eid] = 0
 
-    // Clear component bitmasks
-    entities.forEach(arr => { arr[eid] = 0 })
+    deferredEntityRemovals.length = 0
   }
 
   /**
@@ -90,8 +89,8 @@ export const Entity = (config, registry) => {
    * @param {uint32} eid        - The entity id to remove.
    */
   const removeEntity = (eid) => {
-    deferredEntityRemovals.push(() => _removeEntity(eid))
+    deferredEntityRemovals.push(eid)
   }
 
-  return { entityCount, addEntity, removeEntity, deferredEntityRemovals }
+  return { entityCount, addEntity, removeEntity, commitEntityRemovals }
 }

--- a/src/Registry.js
+++ b/src/Registry.js
@@ -1,5 +1,8 @@
-export const Registry = ({ maxEntities, maxComponentTypes }) => ({
-  entities: Array(Math.ceil(maxComponentTypes / 32)).fill(null).map(() => new Uint32Array(maxEntities)),
+export const Registry = ({ maxEntities, maxGenerations }) => ({
+  entities: Array.from(
+    { length: maxGenerations },
+    () => new Uint32Array(maxEntities)
+  ),
   components: {},
   systems: {}
 })

--- a/src/System.js
+++ b/src/System.js
@@ -1,7 +1,7 @@
 export const System = (
   config,
   registry,
-  deferredEntityRemovals,
+  commitEntityRemovals,
   deferredComponentRemovals
 ) => {
   const { entities, components, systems } = registry
@@ -222,9 +222,7 @@ export const System = (
     while (deferredComponentRemovals.length > 0) {
       deferredComponentRemovals.shift()()
     }
-    while (deferredEntityRemovals.length > 0) {
-      deferredEntityRemovals.shift()()
-    }
+    commitEntityRemovals()
   }
 
   /**

--- a/src/System.js
+++ b/src/System.js
@@ -2,7 +2,7 @@ export const System = (
   config,
   registry,
   commitEntityRemovals,
-  deferredComponentRemovals
+  commitComponentRemovals
 ) => {
   const { entities, components, systems } = registry
 
@@ -117,7 +117,7 @@ export const System = (
     components: componentDependencies = [],
     enter,
     update,
-    exit ,
+    exit
   }) => {
     const localEntities = []
 
@@ -135,7 +135,9 @@ export const System = (
 
     const componentManagers = componentDependencies.map(dep => {
       if (components[dep] === undefined) {
-        throw new Error(`❌ Cannot register system '${name}', '${dep}' is not a registered component.`)
+        throw new Error(
+          `❌ Cannot register system '${name}', '${dep}' is not a registered component.`
+        )
       }
       return components[dep]
     })
@@ -152,14 +154,16 @@ export const System = (
     system.masks = masks
 
     // Checks if an entity mask matches the system's
-    system.check = (eid) => Object.keys(masks).every((generationId) => {
-      const eMask = entities[generationId][eid]
-      const sMask = masks[generationId]
-      return (eMask & sMask) === sMask
-    })
+    system.check = eid =>
+      Object.keys(masks).every(generationId => {
+        const eMask = entities[generationId][eid]
+        const sMask = masks[generationId]
+        return (eMask & sMask) === sMask
+      })
 
-    system.checkComponent = (componentManager) =>
-      (masks[componentManager._generationId] & componentManager._bitflag) === componentManager._bitflag
+    system.checkComponent = componentManager =>
+      (masks[componentManager._generationId] & componentManager._bitflag) ===
+      componentManager._bitflag
 
     // Define execute function which executes each local entity
     const updateFn = update ? update(...componentManagers) : null
@@ -219,9 +223,7 @@ export const System = (
    * @private
    */
   const applyRemovalDeferrals = () => {
-    while (deferredComponentRemovals.length > 0) {
-      deferredComponentRemovals.shift()()
-    }
+    commitComponentRemovals()
     commitEntityRemovals()
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,12 +30,7 @@ export default (worldConfig = {}) => {
   const config = Config(worldConfig)
   const registry = Registry(config)
 
-  const {
-    entityCount,
-    addEntity,
-    removeEntity,
-    commitEntityRemovals
-  } = Entity(config, registry)
+  const { entityCount, addEntity, removeEntity, commitEntityRemovals } = Entity(config, registry)
 
   const {
     registerComponent,
@@ -43,7 +38,7 @@ export default (worldConfig = {}) => {
     removeComponent,
     removeAllComponents,
     hasComponent,
-    deferredComponentRemovals
+    commitComponentRemovals
   } = Component(config, registry, dataManager)
 
   const {
@@ -51,10 +46,10 @@ export default (worldConfig = {}) => {
     registerSystem,
     toggle,
     step
-  } = System(config, registry, commitEntityRemovals, deferredComponentRemovals)
+  } = System(config, registry, commitEntityRemovals, commitComponentRemovals)
 
   let queryCount = 0
-  const createQuery = components => registerSystem({ name: `query-${queryCount++}`, components }).localEntities
+  const createQuery = (components) => registerSystem({ name: `query-${queryCount++}`, components }).localEntities
 
   return {
     TYPES: TYPES_ENUM,

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,6 @@ export default (worldConfig = {}) => {
     addComponent,
     removeComponent,
     removeAllComponents,
-    updateComponent,
-    getComponent,
     hasComponent,
     deferredComponentRemovals
   } = Component(config, registry, dataManager)
@@ -69,8 +67,6 @@ export default (worldConfig = {}) => {
     removeComponent,
     removeAllComponents,
     addComponent,
-    updateComponent,
-    getComponent,
     hasComponent,
     registerSystem,
     createQuery,

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export default (worldConfig = {}) => {
     entityCount,
     addEntity,
     removeEntity,
-    deferredEntityRemovals
+    commitEntityRemovals
   } = Entity(config, registry)
 
   const {
@@ -53,7 +53,7 @@ export default (worldConfig = {}) => {
     registerSystem,
     toggle,
     step
-  } = System(config, registry, deferredEntityRemovals, deferredComponentRemovals)
+  } = System(config, registry, commitEntityRemovals, deferredComponentRemovals)
 
   let queryCount = 0
   const createQuery = components => registerSystem({ name: `query-${queryCount++}`, components }).localEntities


### PR DESCRIPTION
On my benchmark, here are the numbers before:

```
bitecs
  entity_cycle    643 op/s
  add_remove      1,437 op/s
```

And after:

```
bitecs
  entity_cycle    3,323 op/s
  add_remove      6,510 op/s
```

Each commit should okay to cherry-pick if you don't want to merge the whole PR.