### PR TITLE
Fix Map DataManager

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -6,7 +6,7 @@ import { $entityMasks } from './Entity.js'
 export const $componentMap = Symbol('componentMap')
 export const $deferredComponentRemovals = Symbol('de$deferredComponentRemovals')
 
-export const defineComponent = (schema) => schema.constructor.name === 'Map' ? schema : alloc(schema)
+export const defineComponent = (schema) => alloc(schema)
 
 export const incrementBitflag = (world) => {
   world[$bitflag] *= 2

--- a/src/DataManager.js
+++ b/src/DataManager.js
@@ -52,6 +52,11 @@ export const $serializeShadow = Symbol('$serializeShadow')
 
 export const alloc = (schema, size=1000000) => {
   const $manager = Symbol('manager')
+
+  if (schema.constructor.name === 'Map') {
+    schema[$managerSize] = size;
+    return schema;
+  }
   
   managers[$manager] = {
     [$managerSize]: size,

--- a/src/Query.js
+++ b/src/Query.js
@@ -120,7 +120,6 @@ export const defineQuery = (components) => {
 // TODO: archetype graph
 export const queryCheckEntity = (world, query, eid) => {
   const { masks, notMasks, generations } = world[$queryMap].get(query)
-  console.log(notMasks)
   for (let i = 0; i < generations.length; i++) {
     const generationId = generations[i]
     const qMask = masks[generationId]


### PR DESCRIPTION
This PR sets the `$managerSize` property on the `Map` passed to `defineComponent` this is used in queries to determine the size of the `enabled` array. Without this size, queries with only `Map` components will have empty `enabled` arrays and their components will not be removed.

Also I removed a stray console.log