### PR TITLE
Prevent error when using hasComponent on an unregistered component

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -34,7 +34,9 @@ export const registerComponents = (world, components) => {
 }
 
 export const hasComponent = (world, component, eid) => {
-  const { generationId, bitflag } = world[$componentMap].get(component)
+  const registeredComponent = world[$componentMap].get(component)
+  if (!registeredComponent) return
+  const { generationId, bitflag } = registeredComponent
   const mask = world[$entityMasks][generationId][eid]
   return (mask & bitflag) === bitflag
 }


### PR DESCRIPTION
This PR makes it safe to call hasComponent on unregistered components and prevent getting the TypeError `Cannot destructure property 'generationId' of 'world[$componentMap].get(...)' as it is undefined.`.