### PR TITLE
defineComponent typings improvement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,23 @@ declare module 'bitecs' {
     Float32Array |
     Float64Array
 
+  type ArrayByType = {
+    ['bool']: boolean[];
+    [Types.i8]: Int8Array;
+    [Types.ui8]: Uint8Array;
+    [Types.ui8c]: Uint8ClampedArray;
+    [Types.i16]: Int16Array;
+    [Types.ui16]: Uint16Array;
+    [Types.i32]: Int32Array;
+    [Types.ui32]: Uint32Array;
+    [Types.f32]: Float32Array;
+    [Types.f64]: Float64Array;
+  }
+
+  type ComponentType<T extends ISchema> = {
+    [key in keyof T]: T[key] extends Type ? ArrayByType[T[key]] : T[key] extends ISchema ? ComponentType<T[key]> : unknown;
+  }
+
   interface IWorld {
     [key: string]: any
   }
@@ -57,13 +74,13 @@ declare module 'bitecs' {
 
   type System = (world: IWorld) => void
 
-  
+
   export function createWorld (size?: number): IWorld
   export function addEntity (world: IWorld): number
   export function removeEntity (world: IWorld, eid: number): void
   export function registerComponent (world: IWorld, component: IComponent): void
   export function registerComponents (world: IWorld, components: IComponent[]): void
-  export function defineComponent (schema: ISchema): IComponent
+  export function defineComponent <T extends ISchema>(schema: T): ComponentType<T>
   export function addComponent (world: IWorld, component: IComponent, eid: number): void
   export function removeComponent (world: IWorld, component: IComponent, eid: number): void
   export function hasComponent (world: IWorld, component: IComponent, eid: number): boolean


### PR DESCRIPTION
With these changes we'll be able to achieve type control in compile time for components declared with `defineComponent` function
```ts
import { defineComponent, Types } from "bitecs";

export const CCircle = defineComponent({
  radius: Types.ui8,
  bolVal: "bool",
  complex: {
    some: Types.i8,
    someOther: {
      a: Types.ui8c,
    },
  },
});

CCircle.complex.someOther.a = "WAT?"; // TS2322: Type 'string' is not assignable to type 'Uint8ClampedArray'.
CCircle.complex.someOther.a[23] = "4"; // TS2322: Type 'string' is not assignable to type 'number'.
CCircle.complex.someOther.a[23] = 4; // OK
CCircle.complex.someOther.a[23] = -4.2; // OK, but type of a is Uint8ClampedArray so... i don't know
CCircle.bolVal[2] = false; // OK
CCircle.bolVal[2] = "true"; // TS2322: Type 'string' is not assignable to type 'boolean'.
CCircle.notExist[3] = 3; // TS2339: Property 'notExist' does not exist on type
                         // 'ComponentType{ radius: "ui8"; complex: { some: "i8"; someOther: { a: "ui8c"; }; }; }>'.
let radius = CCircle.radius[1]; // radius: number - OK
```
And autocomplete will work (WebStorm for example):
![image](https://user-images.githubusercontent.com/83572844/117998665-c93c7100-b34c-11eb-9941-e6388e7b7d05.png)
