### PR TITLE
remove from local entities map when removing entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitecs",
-  "version": "0.3.18",
+  "version": "0.3.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitecs",
-      "version": "0.3.18",
+      "version": "0.3.20",
       "license": "MPL-2.0",
       "devDependencies": {
         "boxen": "^5.0.1",

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -1,6 +1,6 @@
 import { resizeComponents } from './Component.js'
 import { $notQueries, $queries, queryAddEntity, queryCheckEntity, queryRemoveEntity } from './Query.js'
-import { resizeWorlds } from './World.js'
+import { $localEntities, $localEntityLookup, resizeWorlds } from './World.js'
 import { setSerializationResized } from './Serialize.js'
 
 export const $entityMasks = Symbol('entityMasks')
@@ -106,6 +106,10 @@ export const removeEntity = (world, eid) => {
   // remove all eid state from world
   world[$entitySparseSet].remove(eid)
   world[$entityComponents].delete(eid)
+
+  // remove from deserializer mapping
+  world[$localEntities].delete(world[$localEntityLookup].get(eid))
+  world[$localEntityLookup].delete(eid)
 
   // Clear entity bitmasks
   for (let i = 0; i < world[$entityMasks].length; i++) world[$entityMasks][i][eid] = 0

--- a/src/Serialize.js
+++ b/src/Serialize.js
@@ -1,7 +1,7 @@
 import { $indexBytes, $indexType, $isEidType, $serializeShadow, $storeBase, $storeFlattened, $tagStore, createShadow } from "./Storage.js"
 import { $componentMap, addComponent, hasComponent } from "./Component.js"
 import { $entityArray, $entitySparseSet, addEntity, eidToWorld } from "./Entity.js"
-import { $localEntities } from "./World.js"
+import { $localEntities, $localEntityLookup } from "./World.js"
 
 export const DESERIALIZE_MODE = {
   REPLACE: 0,
@@ -219,6 +219,7 @@ export const defineDeserializer = (target) => {
     }
 
     const localEntities = world[$localEntities]
+    const localEntityLookup = world[$localEntityLookup]
 
     const view = new DataView(packet)
     let where = 0
@@ -249,6 +250,7 @@ export const defineDeserializer = (target) => {
           } else {
             const newEid = addEntity(world)
             localEntities.set(eid, newEid)
+            localEntityLookup.set(newEid, eid)
             newEntities.set(eid, newEid)
             eid = newEid
           }

--- a/src/World.js
+++ b/src/World.js
@@ -9,6 +9,7 @@ export const $resizeThreshold = Symbol('resizeThreshold')
 export const $bitflag = Symbol('bitflag')
 export const $archetypes = Symbol('archetypes')
 export const $localEntities = Symbol('localEntities')
+export const $localEntityLookup = Symbol('localEntityLookp')
 
 export const worlds = []
 
@@ -66,6 +67,7 @@ export const resetWorld = (world) => {
   world[$dirtyQueries] = new Set()
 
   world[$localEntities] = new Map()
+  world[$localEntityLookup] = new Map()
 
   return world
 }


### PR DESCRIPTION
removing an entity when deserializing in map mode breaks the mapping and causes errors. My proposed change removes deleted entities from the mapping to avoid this, allowing you to reload an entity that has been previously removed.