### PR TITLE
Improve typings to allow for generic world type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,44 +90,44 @@ declare module 'bitecs' {
 
   export type Component = IComponent | ComponentType<ISchema>
 
-  export type QueryModifier<W extends IWorld> = (c: (IComponent | IComponentProp)[]) => (world: W) => IComponent | QueryModifier<W>
+  export type QueryModifier<W extends IWorld = IWorld> = (c: (IComponent | IComponentProp)[]) => (world: W) => IComponent | QueryModifier<W>
 
-  export type Query<W extends IWorld> = (world: W, clearDiff?: Boolean) => number[]
+  export type Query<W extends IWorld = IWorld> = (world: W, clearDiff?: Boolean) => number[]
 
-  export type System<W extends IWorld, Args extends any[]> = (world: W, ...args: Args) => W
+  export type System<R extends any[], W extends IWorld = IWorld> = (world: W, ...args: R) => W
 
-  export type Serializer<W extends IWorld> = (target: W | number[]) => ArrayBuffer
-  export type Deserializer<W extends IWorld> = (world: W, packet: ArrayBuffer, mode?: DESERIALIZE_MODE) => number[]
+  export type Serializer<W extends IWorld = IWorld> = (target: W | number[]) => ArrayBuffer
+  export type Deserializer<W extends IWorld = IWorld> = (world: W, packet: ArrayBuffer, mode?: DESERIALIZE_MODE) => number[]
 
   export function setDefaultSize(size: number): void
-  export function createWorld<T extends IWorld>(obj?: T): T
-  export function resetWorld<W extends IWorld>(world: W): W
-  export function deleteWorld<W extends IWorld>(world: W): void
-  export function addEntity<W extends IWorld>(world: W): number
-  export function removeEntity<W extends IWorld>(world: W, eid: number): void
+  export function createWorld<W extends IWorld = IWorld>(obj?: W): W
+  export function resetWorld<W extends IWorld = IWorld>(world: W): W
+  export function deleteWorld<W extends IWorld = IWorld>(world: W): void
+  export function addEntity<W extends IWorld = IWorld>(world: W): number
+  export function removeEntity<W extends IWorld = IWorld>(world: W, eid: number): void
 
-  export function registerComponent<W extends IWorld>(world: W, component: Component): void
-  export function registerComponents<W extends IWorld>(world: W, components: Component[]): void
+  export function registerComponent<W extends IWorld = IWorld>(world: W, component: Component): void
+  export function registerComponents<W extends IWorld = IWorld>(world: W, components: Component[]): void
   export function defineComponent<T extends ISchema>(schema?: T): ComponentType<T>
   export function defineComponent<T>(schema?: any): T
-  export function addComponent<W extends IWorld>(world: W, component: Component, eid: number, reset?: boolean): void
-  export function removeComponent<W extends IWorld>(world: W, component: Component, eid: number, reset?: boolean): void
-  export function hasComponent<W extends IWorld>(world: W, component: Component, eid: number): boolean
-  export function getEntityComponents<W extends IWorld>(world: W, eid: number): Component[]
+  export function addComponent<W extends IWorld = IWorld>(world: W, component: Component, eid: number, reset?: boolean): void
+  export function removeComponent<W extends IWorld = IWorld>(world: W, component: Component, eid: number, reset?: boolean): void
+  export function hasComponent<W extends IWorld = IWorld>(world: W, component: Component, eid: number): boolean
+  export function getEntityComponents<W extends IWorld = IWorld>(world: W, eid: number): Component[]
 
-  export function defineQuery<W extends IWorld>(components: (Component | QueryModifier<W>)[]): Query<W>
-  export function Changed<W extends IWorld>(c: Component | ISchema): Component | QueryModifier<W>
-  export function Not<W extends IWorld>(c: Component | ISchema): Component | QueryModifier<W>
-  export function enterQuery<W extends IWorld>(query: Query<W>): Query<W>
-  export function exitQuery<W extends IWorld>(query: Query<W>): Query<W>
-  export function resetChangedQuery<W extends IWorld>(world: W, query: Query<W>): Query<W>
-  export function removeQuery<W extends IWorld>(world: W, query: Query<W>): Query<W>
-  export function commitRemovals<W extends IWorld>(world: W): void
+  export function defineQuery<W extends IWorld = IWorld>(components: (Component | QueryModifier<W>)[]): Query<W>
+  export function Changed<W extends IWorld = IWorld>(c: Component | ISchema): Component | QueryModifier<W>
+  export function Not<W extends IWorld = IWorld>(c: Component | ISchema): Component | QueryModifier<W>
+  export function enterQuery<W extends IWorld = IWorld>(query: Query<W>): Query<W>
+  export function exitQuery<W extends IWorld = IWorld>(query: Query<W>): Query<W>
+  export function resetChangedQuery<W extends IWorld = IWorld>(world: W, query: Query<W>): Query<W>
+  export function removeQuery<W extends IWorld = IWorld>(world: W, query: Query<W>): Query<W>
+  export function commitRemovals<W extends IWorld = IWorld>(world: W): void
 
-  export function defineSystem<W extends IWorld, Args extends any[]>(update: (world: W, ...args: Args) => W): System<W, Args>
+  export function defineSystem<R extends any[], W extends IWorld = IWorld>(update: (world: W, ...args: R) => W): System<R, W>
 
-  export function defineSerializer<W extends IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>, maxBytes?: number): Serializer<W>
-  export function defineDeserializer<W extends IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>): Deserializer<W>
+  export function defineSerializer<W extends IWorld = IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>, maxBytes?: number): Serializer<W>
+  export function defineDeserializer<W extends IWorld = IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>): Deserializer<W>
   
   export function pipe(...fns: ((...args: any[]) => any)[]): (...input: any[]) => any
   

--- a/index.d.ts
+++ b/index.d.ts
@@ -90,44 +90,44 @@ declare module 'bitecs' {
 
   export type Component = IComponent | ComponentType<ISchema>
 
-  export type QueryModifier = (c: (IComponent | IComponentProp)[]) => (world: IWorld) => IComponent | QueryModifier
+  export type QueryModifier<W extends IWorld> = (c: (IComponent | IComponentProp)[]) => (world: W) => IComponent | QueryModifier<W>
 
-  export type Query = (world: IWorld, clearDiff?: Boolean) => number[]
+  export type Query<W extends IWorld> = (world: W, clearDiff?: Boolean) => number[]
 
-  export type System = (world: IWorld, ...args: any[]) => IWorld
+  export type System<W extends IWorld, Args extends any[]> = (world: W, ...args: Args) => W
 
-  export type Serializer = (target: IWorld | number[]) => ArrayBuffer
-  export type Deserializer = (world: IWorld, packet: ArrayBuffer, mode?: DESERIALIZE_MODE) => number[]
+  export type Serializer<W extends IWorld> = (target: W | number[]) => ArrayBuffer
+  export type Deserializer<W extends IWorld> = (world: W, packet: ArrayBuffer, mode?: DESERIALIZE_MODE) => number[]
 
   export function setDefaultSize(size: number): void
   export function createWorld<T extends IWorld>(obj?: T): T
-  export function resetWorld(world: IWorld): IWorld
-  export function deleteWorld(world: IWorld): void
-  export function addEntity(world: IWorld): number
-  export function removeEntity(world: IWorld, eid: number): void
+  export function resetWorld<W extends IWorld>(world: W): W
+  export function deleteWorld<W extends IWorld>(world: W): void
+  export function addEntity<W extends IWorld>(world: W): number
+  export function removeEntity<W extends IWorld>(world: W, eid: number): void
 
-  export function registerComponent(world: IWorld, component: Component): void
-  export function registerComponents(world: IWorld, components: Component[]): void
+  export function registerComponent<W extends IWorld>(world: W, component: Component): void
+  export function registerComponents<W extends IWorld>(world: W, components: Component[]): void
   export function defineComponent<T extends ISchema>(schema?: T): ComponentType<T>
   export function defineComponent<T>(schema?: any): T
-  export function addComponent(world: IWorld, component: Component, eid: number, reset?: boolean): void
-  export function removeComponent(world: IWorld, component: Component, eid: number, reset?: boolean): void
-  export function hasComponent(world: IWorld, component: Component, eid: number): boolean
-  export function getEntityComponents(world: IWorld, eid: number): Component[]
+  export function addComponent<W extends IWorld>(world: W, component: Component, eid: number, reset?: boolean): void
+  export function removeComponent<W extends IWorld>(world: W, component: Component, eid: number, reset?: boolean): void
+  export function hasComponent<W extends IWorld>(world: W, component: Component, eid: number): boolean
+  export function getEntityComponents<W extends IWorld>(world: W, eid: number): Component[]
 
-  export function defineQuery(components: (Component | QueryModifier)[]): Query
-  export function Changed(c: Component | ISchema): Component | QueryModifier
-  export function Not(c: Component | ISchema): Component | QueryModifier
-  export function enterQuery(query: Query): Query
-  export function exitQuery(query: Query): Query
-  export function resetChangedQuery(world: IWorld, query: Query): Query
-  export function removeQuery(world: IWorld, query: Query): Query
-  export function commitRemovals(world: IWorld): void
+  export function defineQuery<W extends IWorld>(components: (Component | QueryModifier<W>)[]): Query<W>
+  export function Changed<W extends IWorld>(c: Component | ISchema): Component | QueryModifier<W>
+  export function Not<W extends IWorld>(c: Component | ISchema): Component | QueryModifier<W>
+  export function enterQuery<W extends IWorld>(query: Query<W>): Query<W>
+  export function exitQuery<W extends IWorld>(query: Query<W>): Query<W>
+  export function resetChangedQuery<W extends IWorld>(world: W, query: Query<W>): Query<W>
+  export function removeQuery<W extends IWorld>(world: W, query: Query<W>): Query<W>
+  export function commitRemovals<W extends IWorld>(world: W): void
 
-  export function defineSystem(update: (world: IWorld, ...args: any[]) => IWorld): System
+  export function defineSystem<W extends IWorld, Args extends any[]>(update: (world: W, ...args: Args) => W): System<W, Args>
 
-  export function defineSerializer(target: IWorld | Component[] | IComponentProp[] | QueryModifier, maxBytes?: number): Serializer
-  export function defineDeserializer(target: IWorld | Component[] | IComponentProp[] | QueryModifier): Deserializer
+  export function defineSerializer<W extends IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>, maxBytes?: number): Serializer<W>
+  export function defineDeserializer<W extends IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>): Deserializer<W>
   
   export function pipe(...fns: ((...args: any[]) => any)[]): (...input: any[]) => any
   

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ declare module 'bitecs' {
 
   export type Query<W extends IWorld = IWorld> = (world: W, clearDiff?: Boolean) => number[]
 
-  export type System<R extends any[], W extends IWorld = IWorld> = (world: W, ...args: R) => W
+  export type System<R extends any[] = any[], W extends IWorld = IWorld> = (world: W, ...args: R) => W
 
   export type Serializer<W extends IWorld = IWorld> = (target: W | number[]) => ArrayBuffer
   export type Deserializer<W extends IWorld = IWorld> = (world: W, packet: ArrayBuffer, mode?: DESERIALIZE_MODE) => number[]
@@ -124,7 +124,7 @@ declare module 'bitecs' {
   export function removeQuery<W extends IWorld = IWorld>(world: W, query: Query<W>): Query<W>
   export function commitRemovals<W extends IWorld = IWorld>(world: W): void
 
-  export function defineSystem<R extends any[], W extends IWorld = IWorld>(update: (world: W, ...args: R) => W): System<R, W>
+  export function defineSystem<R extends any[] = any[], W extends IWorld = IWorld>(update: (world: W, ...args: R) => W): System<R, W>
 
   export function defineSerializer<W extends IWorld = IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>, maxBytes?: number): Serializer<W>
   export function defineDeserializer<W extends IWorld = IWorld>(target: W | Component[] | IComponentProp[] | QueryModifier<W>): Deserializer<W>


### PR DESCRIPTION
Currently, the typings for BitECS only allow for a single `World` type, `IWorld` (although there is support for a different `World` type when creating the world). `IWorld` is defined as a map that relates any string key to any value. This makes it difficult to place any value on `IWorld` in a type-safe way: it's impossible to make a type that guarantees a key's existence. Thus, this PR adds support for a generic `World` type (defaulting to `IWorld` so that this is not a breaking change) in case users want to add stricter types to their systems.

Additionally, this PR modifies the `System` type so that it takes a list of strict parameters, allowing the type system to be responsible for ensuring that parameters get filled in.

All new generic parameters come with the originals as defaults (`IWorld` for the generic world, `...args: any[]` for generic args) so that there are no breaking changes, and all original code will function the same as currently.

A new, stricter version of a system would appear as follows:
```typescript
// -- src/types/world.ts
import { IWorld } from 'bitecs'
import { QuadTree } from '../utils/quadtree'

export interface World extends IWorld {
  time: {
    delta: number
    elapsed: number
    then: number
  }
  collisionMap: QuadTree
}
```

```typescript
// -- src/systems/time.ts
import { defineSystem } from 'bitecs'

import { World } from '../types/world'

export default function createTimeSystem() {
  // Since these parameters exist on the system definition,
  // they will now be required each time we run the system.
  //
  // See `src/world.ts` to see this in action.
  return defineSystem((world: World, t: number, dt: number) => {
    const { time } = world

    time.delta = dt
    time.elapsed += dt
    time.then = t

    return world
  })
}
```

```typescript
// -- src/world.ts
import Phaser from 'phaser'
import {
  createWorld,
} from 'bitecs'

import createTimeSystem from '../systems/time'

import { World } from '../types/world'

import { QuadTree } from '../utils/quadtree'

export default class Game extends Phaser.Scene {

  private world!: World
  // Using `ReturnType<>` will ensure that parameters are strictly included.
  // Otherwise, `System` will default to `...args: any[]`.
  private timeSystem!: ReturnType<typeof createTimeSystem>

  constructor() {
    super('game')
  }

  create() {
    this.world = createWorld<World>()
    this.world.time = {
      delta: 0,
      elapsed: 0,
      then: performance.now(),
    }
    this.world.collisionMap = new QuadTree(1, [0, 0, 1000, 1000])

    // Create the systems
    this.timeSystem = createTimeSystem()
  }

  update(t: number, dt: number) {
    // `t` and `dt` are required here: missing them will throw a type error
    this.timeSystem(this.world, t, dt)
  }
}
```