### PR TITLE
add resetAllGlobals functionality

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,7 @@ declare module 'bitecs' {
   export function createWorld<W extends IWorld = IWorld>(obj?: W, size?: number): W
   export function createWorld<W extends IWorld = IWorld>(size?: number): W
   export function resetWorld<W extends IWorld = IWorld>(world: W): W
+  export function resetAllGlobals(): void
   export function deleteWorld<W extends IWorld = IWorld>(world: W): void
   export function addEntity<W extends IWorld = IWorld>(world: W): number
   export function removeEntity<W extends IWorld = IWorld>(world: W, eid: number): void

--- a/src/Component.js
+++ b/src/Component.js
@@ -5,7 +5,7 @@ import { $entityMasks, getDefaultSize, eidToWorld, $entityComponents, getGlobalS
 
 export const $componentMap = Symbol('componentMap')
 
-export const components = []
+export let components = []
 
 export const resetComponentGlobals = () => (components = []);
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -7,6 +7,9 @@ export const $componentMap = Symbol('componentMap')
 
 export const components = []
 
+export const resetComponentGlobals = () => (components = []);
+
+
 export const resizeComponents = (size) => {
   components.forEach(component => resizeStore(component, size))
 }

--- a/src/Serialize.js
+++ b/src/Serialize.js
@@ -10,7 +10,14 @@ export const DESERIALIZE_MODE = {
   MAP: 2
 }
 
+let newEntities = new Map()
 let resized = false
+
+export const resetSerializeGlobals = () => {
+  resized = false;
+  newEntities = new Map();
+};
+
 
 export const setSerializationResized = v => { resized = v }
 
@@ -266,8 +273,6 @@ export const defineSerializer = (target, maxBytes = 20000000) => {
     return buffer.slice(0, where)
   }
 }
-
-const newEntities = new Map()
 
 /**
  * Defines a new deserializer which targets the given components to deserialize onto a given world.

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -28,7 +28,7 @@ export const $indexBytes = Symbol('indexBytes')
 
 export const $isEidType = Symbol('isEidType')
 
-const stores = {}
+let stores = {}
 
 export const resetStorageGlobals = () => (stores = {});
 

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -30,6 +30,8 @@ export const $isEidType = Symbol('isEidType')
 
 const stores = {}
 
+export const resetStorageGlobals = () => (stores = {});
+
 // const alloc = createAllocator()
 
 export const resize = (ta, size) => {

--- a/src/World.js
+++ b/src/World.js
@@ -11,7 +11,7 @@ export const $archetypes = Symbol('archetypes')
 export const $localEntities = Symbol('localEntities')
 export const $localEntityLookup = Symbol('localEntityLookup')
 
-export const worlds = []
+export let worlds = []
 
 export const resetWorldGlobals = () => (worlds = []);
 

--- a/src/World.js
+++ b/src/World.js
@@ -13,6 +13,8 @@ export const $localEntityLookup = Symbol('localEntityLookup')
 
 export const worlds = []
 
+export const resetWorldGlobals = () => (worlds = []);
+
 export const resizeWorlds = (size) => {
   worlds.forEach(world => {
     world[$size] = size

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import { createWorld, resetWorld, deleteWorld, getWorldComponents, getAllEntities } from './World.js'
-import { addEntity, removeEntity, setDefaultSize, getEntityComponents, entityExists } from './Entity.js'
-import { defineComponent, registerComponent, registerComponents, hasComponent, addComponent, removeComponent } from './Component.js'
+import { createWorld, resetWorld, deleteWorld, getWorldComponents, getAllEntities, resetWorldGlobals } from './World.js'
+import { addEntity, removeEntity, setDefaultSize, getEntityComponents, entityExists, resetGlobals as resetEntityGlobals } from './Entity.js'
+import { defineComponent, registerComponent, registerComponents, hasComponent, addComponent, removeComponent, resetComponentGlobals } from './Component.js'
 import { defineSystem } from './System.js'
 import { defineQuery, enterQuery, exitQuery, Changed, Not, commitRemovals, resetChangedQuery, removeQuery } from './Query.js'
-import { defineSerializer, defineDeserializer, DESERIALIZE_MODE } from './Serialize.js'
-import { parentArray } from './Storage.js'
+import { defineSerializer, defineDeserializer, DESERIALIZE_MODE, resetSerializeGlobals } from './Serialize.js'
+import { parentArray, resetStorageGlobals } from './Storage.js'
 import { TYPES_ENUM } from './Constants.js'
 
 export const pipe = (...fns) => (input) => {
@@ -14,6 +14,14 @@ export const pipe = (...fns) => (input) => {
     tmp = fn(tmp)
   }
   return tmp
+}
+
+export const resetAllGlobals = () => {
+  resetComponentGlobals()
+  resetSerializeGlobals()
+  resetWorldGlobals()
+  resetStorageGlobals()
+  resetEntityGlobals()
 }
 
 export const Types = TYPES_ENUM


### PR DESCRIPTION
re issue #86,  here's a very simple PR implementing `resetAllGlobals`. Note that a function called `resetGlobals` is already defined in `Entity.js`, so i went with `resetAllGlobals` to avoid shadowing that function name.