### PR TITLE
Fix output of ESM watch

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -205,7 +205,7 @@ if (watch) {
     format: 'esm',
     platform: 'node',
     sourcemap: true,
-    outfile: outfileCjs,
+    outfile: outfileEsm,
     watch: {
       onRebuild (error) {
         if (error) {


### PR DESCRIPTION
ESM watch was updating the CJS output file instead of the ESM one.