### PR TITLE
Allow configuration of removed id recycling threshold

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,7 @@ declare module 'bitecs' {
   export type Deserializer<W extends IWorld = IWorld> = (world: W, packet: ArrayBuffer, mode?: DESERIALIZE_MODE) => number[]
 
   export function setDefaultSize(size: number): void
+  export function setRemovedRecycleThreshold(newThreshold: number): void
   export function createWorld<W extends IWorld = IWorld>(obj?: W, size?: number): W
   export function createWorld<W extends IWorld = IWorld>(size?: number): W
   export function resetWorld<W extends IWorld = IWorld>(world: W): W

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -22,10 +22,13 @@ export const getGlobalSize = () => globalSize
 
 // removed eids should also be global to prevent memory leaks
 const removed = []
+const defaultRemovedReuseThreshold = 0.01
+let removedReuseThreshold = defaultRemovedReuseThreshold
 
 export const resetGlobals = () => {
   globalSize = defaultSize
   globalEntityCursor = 0
+  removedReuseThreshold = defaultRemovedReuseThreshold
   removed.length = 0
 }
 
@@ -50,6 +53,16 @@ export const setDefaultSize = newSize => {
   console.info(`👾 bitECS - resizing all data stores from ${oldSize} to ${newSize}`)
 }
 
+/**
+ * Sets the number of entities that must be removed before removed entity ids begin to be recycled.
+ * This should be set to as a % (0-1) of `defaultSize` that you would never likely remove/add on a single frame.
+ *
+ * @param {number} newThreshold
+ */
+export const setRemovedRecycleThreshold = newThreshold => {
+  removedReuseThreshold = newThreshold
+}
+
 export const getEntityCursor = () => globalEntityCursor
 export const getRemovedEntities = () => removed
 
@@ -71,7 +84,7 @@ export const addEntity = (world) => {
     setDefaultSize(size + amount)
   }
   
-  const eid = removed.length > Math.round(defaultSize * 0.01) ? removed.shift() : globalEntityCursor++
+  const eid = removed.length > Math.round(defaultSize * removedReuseThreshold) ? removed.shift() : globalEntityCursor++
   
   world[$entitySparseSet].add(eid)
   eidToWorld.set(eid, world)

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { createWorld, resetWorld, deleteWorld, getWorldComponents, getAllEntities } from './World.js'
-import { addEntity, removeEntity, setDefaultSize, getEntityComponents, entityExists } from './Entity.js'
+import { addEntity, removeEntity, setDefaultSize, setRemovedRecycleThreshold, getEntityComponents, entityExists } from './Entity.js'
 import { defineComponent, registerComponent, registerComponents, hasComponent, addComponent, removeComponent } from './Component.js'
 import { defineSystem } from './System.js'
 import { defineQuery, enterQuery, exitQuery, Changed, Not, commitRemovals, resetChangedQuery, removeQuery } from './Query.js'
@@ -21,6 +21,7 @@ export const Types = TYPES_ENUM
 export {
 
   setDefaultSize,
+  setRemovedRecycleThreshold,
   createWorld,
   resetWorld,
   deleteWorld,

--- a/test/integration/Entity.test.js
+++ b/test/integration/Entity.test.js
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert'
-import { getEntityCursor, getRemovedEntities, resetGlobals } from '../../src/Entity.js'
+import { getEntityCursor, getRemovedEntities, resetGlobals, setRemovedRecycleThreshold } from '../../src/Entity.js'
 import { createWorld, addEntity, removeEntity } from '../../src/index.js'
 
 describe('Entity Integration Tests', () => {
@@ -33,7 +33,7 @@ describe('Entity Integration Tests', () => {
     strictEqual(removed[1], 1)
     strictEqual(removed[2], 2)
   })
-  it('should recycle entity IDs after 1% have been removed', () => {
+  it('should recycle entity IDs after 1% have been removed by default', () => {
     const world = createWorld()
 
     for (let i = 0; i < 1500; i++) {
@@ -45,6 +45,41 @@ describe('Entity Integration Tests', () => {
     strictEqual(getEntityCursor(), 1500)
 
     for (let i = 0; i < 1000; i++) {
+      removeEntity(world, i)
+    }
+
+    let eid = addEntity(world)
+    strictEqual(eid, 1500)
+
+    eid = addEntity(world)
+    strictEqual(eid, 1501)
+
+    eid = addEntity(world)
+    strictEqual(eid, 1502)
+
+    eid = addEntity(world)
+    strictEqual(eid, 1503)
+
+    removeEntity(world, eid)
+
+    eid = addEntity(world)
+    strictEqual(eid, 0)
+
+  })
+  it('should be able to configure % of removed entity IDs before recycle', () => {
+    const world = createWorld()
+
+    setRemovedRecycleThreshold(0.012)
+
+    for (let i = 0; i < 1500; i++) {
+      const eid = addEntity(world)
+      strictEqual(getEntityCursor(), eid+1)
+      strictEqual(eid, i)
+    }
+
+    strictEqual(getEntityCursor(), 1500)
+
+    for (let i = 0; i < 1200; i++) {
       removeEntity(world, i)
     }
 


### PR DESCRIPTION
Currently removed entity id's are recycled once 1% of `defaultSize` entities have been removed. This PR allows this threshold to be configured by the application. This is still not a complete solution to the issues discussed in #68 but allows the application to set a value that makes it less likely to happen based on its own usage patterns.