### PR TITLE
Ensure removedReuseThreshold and globalSize are used

### DIFF
--- a/src/Entity.js
+++ b/src/Entity.js
@@ -89,7 +89,7 @@ export const addEntity = (world) => {
 
   const eid = world[$manualEntityRecycling]
     ? removed.length ? removed.shift() : globalEntityCursor++
-    : removed.length > Math.round(defaultSize * defaultRemovedReuseThreshold) ? removed.shift() : globalEntityCursor++
+    : removed.length > Math.round(globalSize * removedReuseThreshold) ? removed.shift() : globalEntityCursor++
 
   if (eid > world[$size]) throw new Error("bitECS - max entities reached")
 


### PR DESCRIPTION
The removedReuseThreshold can be set via a setter but its actually never used in the code. Additionaly the size for the reuse calculation always uses the defaultSize as well.

It should use the set values instead.