### PR TITLE
Add specified types for import vs require for nodenext resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import":  {
+        "default": "./dist/index.mjs",
+        "types": "./dist/index.d.ts"
+      },
+      "require":  {
+        "default": "./dist/index.cjs",
+        "types": "./dist/index.d.ts"
+      }
     }
   },
   "author": {


### PR DESCRIPTION
Typescript was complaining about types for bitECS when I had `moduleResolution: "NodeNext"` set in `tsconfig.json`. Making this specification in `package.json` fixes this