### PR TITLE
Add missing readonly keyword to ComponentType

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -61,7 +61,7 @@ declare module 'bitecs' {
     [key in keyof T]:
       T[key] extends Type
       ? ArrayByType[T[key]]
-      : T[key] extends [infer RT, number]
+      : T[key] extends readonly [infer RT, number]
         ? RT extends Type
           ? Array<ArrayByType[RT]>
           : unknown


### PR DESCRIPTION
This adds a missing readonly keyword for inferring ListTypes inside ComponentType and closes #124 