### PR TITLE
✨ classic: added definePrefab and registerPrefab

### DIFF
--- a/packages/classic/src/entity/Entity.ts
+++ b/packages/classic/src/entity/Entity.ts
@@ -1,4 +1,10 @@
-import { queries, query, queryAddEntity, queryCheckEntity, queryRemoveEntity } from '../query/Query.js';
+import {
+	queries,
+	query,
+	queryAddEntity,
+	queryCheckEntity,
+	queryRemoveEntity,
+} from '../query/Query.js';
 import { resizeWorlds, worlds } from '../world/World.js';
 import {
 	$localEntities,
@@ -12,7 +18,14 @@ import { TODO } from '../utils/types.js';
 import { $notQueries, $queries } from '../query/symbols.js';
 import { Pair, Wildcard } from '../relation/Relation.js';
 import { addComponent, defineComponent, removeComponent } from '../component/Component.js';
-import { $autoRemoveSubject, $isPairComponent, $onTargetRemoved, $pairTarget, $relation, $relationTargetEntities } from '../relation/symbols.js';
+import {
+	$autoRemoveSubject,
+	$isPairComponent,
+	$onTargetRemoved,
+	$pairTarget,
+	$relation,
+	$relationTargetEntities,
+} from '../relation/symbols.js';
 
 let defaultSize = 100000;
 
@@ -82,16 +95,7 @@ export const flushRemovedEntities = (world: World) => {
 	recycled.length = 0;
 };
 
-// TODO: definePrefab?
-export const Prefab = defineComponent()
-export const addPrefab = (world:World) => {
-	const eid = addEntity(world);
-
-	addComponent(world, Prefab, eid);
-
-	return eid;
-}
-
+export const Prefab = defineComponent();
 /**
  * Adds a new entity to the specified world.
  *
@@ -140,32 +144,30 @@ export const removeEntity = (world: World, eid: number) => {
 
 	// check to see if this entity is a relation target at all
 	if (world[$relationTargetEntities].has(eid)) {
-
 		// if it is, iterate over all subjects with any relation to this eid
 		for (const subject of query(world, [Pair(Wildcard, eid)])) {
 			// TODO: can we avoid this check? (subject may have been removed already)
 			if (!entityExists(world, subject)) {
-				continue
+				continue;
 			}
 			// remove the wildcard association with the subject for this entity
-			removeComponent(world, Pair(Wildcard, eid), subject)
+			removeComponent(world, Pair(Wildcard, eid), subject);
 
 			// iterate all relations that the subject has to this entity
 			for (const component of world[$entityComponents].get(subject)!) {
-
 				// TODO: can we avoid this check? (subject may have been removed by this loop already)
 				if (!component[$isPairComponent] || !entityExists(world, subject)) {
-					continue
+					continue;
 				}
-				const relation = component[$relation]
+				const relation = component[$relation];
 
 				if (component[$pairTarget] === eid) {
-					removeComponent(world, component, subject)
+					removeComponent(world, component, subject);
 					if (relation[$autoRemoveSubject]) {
-						removeEntity(world, subject)
+						removeEntity(world, subject);
 					}
 					if (relation[$onTargetRemoved]) {
-						relation[$onTargetRemoved](world, subject, eid)
+						relation[$onTargetRemoved](world, subject, eid);
 					}
 				}
 			}
@@ -177,7 +179,6 @@ export const removeEntity = (world: World, eid: number) => {
 	world[$queries].forEach((q) => {
 		queryRemoveEntity(world, q, eid);
 	});
-
 
 	// Free the entity
 	if (world[$manualEntityRecycling]) recycled.push(eid);

--- a/packages/classic/src/index.ts
+++ b/packages/classic/src/index.ts
@@ -10,7 +10,6 @@ export {
 	worlds,
 } from './world/World.js';
 export {
-	addPrefab,
 	addEntity,
 	removeEntity,
 	setDefaultSize,
@@ -51,6 +50,7 @@ export { parentArray } from './storage/Storage.js';
 export { TYPES_ENUM as Types } from './constants/Constants.js';
 export { pipe } from './utils/pipe.js';
 export * from './relation/Relation.js';
+export * from './prefab/Prefab.js';
 
 // Types
 export * from './component/types.js';
@@ -61,6 +61,7 @@ export * from './system/types.js';
 export * from './world/types.js';
 export * from './utils/types.js';
 export * from './relation/types.js';
+export * from './prefab/types.js';
 
 // Symbols
 import * as worldSymbols from './world/symbols.js';
@@ -69,6 +70,7 @@ import * as componentSymbols from './component/symbols.js';
 import * as querySymbols from './query/symbols.js';
 import * as storageSymbols from './storage/symbols.js';
 import * as relationSymbols from './relation/symbols.js';
+import * as prefabSymbols from './prefab/symbols.js';
 import { archetypeHash } from './query/utils.js';
 
 export const SYMBOLS = {
@@ -78,4 +80,5 @@ export const SYMBOLS = {
 	...querySymbols,
 	...storageSymbols,
 	...relationSymbols,
+	...prefabSymbols,
 };

--- a/packages/classic/src/prefab/Prefab.ts
+++ b/packages/classic/src/prefab/Prefab.ts
@@ -1,0 +1,38 @@
+import { addComponent } from '../component/Component';
+import { Component } from '../component/types';
+import { defineHiddenProperties } from '../utils/defineHiddenProperty';
+import { World } from '../world/types';
+import { Prefab, addEntity } from '../entity/Entity';
+import { $prefabComponents, $worldToPrefab } from './symbols';
+import { PrefabToken } from './types';
+
+export const definePrefab = (components: Component[]) => {
+	const prefab = {};
+
+	defineHiddenProperties(prefab, {
+		[$prefabComponents]: components,
+		[$worldToPrefab]: new Map(),
+	});
+
+	return prefab as PrefabToken;
+};
+
+export const registerPrefab = (world: World, prefab: PrefabToken) => {
+	const eid = addPrefab(world);
+
+	for (const component of prefab[$prefabComponents]) {
+		addComponent(world, component, eid);
+	}
+
+	prefab[$worldToPrefab].set(world, eid);
+
+	return eid;
+};
+
+export const addPrefab = (world: World) => {
+	const eid = addEntity(world);
+
+	addComponent(world, Prefab, eid);
+
+	return eid;
+};

--- a/packages/classic/src/prefab/symbols.ts
+++ b/packages/classic/src/prefab/symbols.ts
@@ -1,0 +1,2 @@
+export const $prefabComponents = Symbol('prefabComponents');
+export const $worldToPrefab = Symbol('worldToPrefab');

--- a/packages/classic/src/prefab/types.ts
+++ b/packages/classic/src/prefab/types.ts
@@ -1,0 +1,8 @@
+import { Component } from '../component/types';
+import { World } from '../world/types';
+import { $prefabComponents, $worldToPrefab } from './symbols';
+
+export type PrefabToken = {
+	[$prefabComponents]: Component[];
+	[$worldToPrefab]: Map<World, number>;
+};

--- a/packages/classic/src/relation/Relation.ts
+++ b/packages/classic/src/relation/Relation.ts
@@ -1,56 +1,82 @@
-import { Schema, World, entityExists, getEntityComponents, removeEntity } from "..";
-import { ComponentType, defineComponent } from "..";
-import { $schema } from "../component/symbols";
-import { defineHiddenProperty } from "../utils/defineHiddenProperty";
-import { $pairsMap, $isPairComponent, $relation, $pairTarget, $onTargetRemoved, $autoRemoveSubject, $exclusiveRelation } from "./symbols";
-import { RelationOptions, RelationType } from "./types";
+import { Schema, World, entityExists, getEntityComponents, removeEntity } from '..';
+import { ComponentType, defineComponent } from '..';
+import { $schema } from '../component/symbols';
+import { $worldToPrefab } from '../prefab/symbols';
+import { defineHiddenProperty } from '../utils/defineHiddenProperty';
+import {
+	$pairsMap,
+	$isPairComponent,
+	$relation,
+	$pairTarget,
+	$onTargetRemoved,
+	$autoRemoveSubject,
+	$exclusiveRelation,
+} from './symbols';
+import { RelationOptions, RelationTarget, RelationType } from './types';
 
-function createOrGetRelationComponent<T extends Schema>(relation: (target: number | string) => ComponentType<T>, schema: T, pairsMap: Map<any, any>, target: string | number) {
-    if (!pairsMap.has(target)) {
-        const component = defineComponent(schema) as any;
-        defineHiddenProperty(component, $isPairComponent, true);
-        defineHiddenProperty(component, $relation, relation);
-        defineHiddenProperty(component, $pairTarget, target);
-        pairsMap.set(target, component);
-    }
-    return pairsMap.get(target) as ComponentType<T>;
+function createOrGetRelationComponent<T extends Schema>(
+	relation: (target: RelationTarget) => ComponentType<T>,
+	schema: T,
+	pairsMap: Map<any, any>,
+	target: RelationTarget
+) {
+	if (!pairsMap.has(target)) {
+		const component = defineComponent(schema) as any;
+		defineHiddenProperty(component, $isPairComponent, true);
+		defineHiddenProperty(component, $relation, relation);
+		defineHiddenProperty(component, $pairTarget, target);
+		pairsMap.set(target, component);
+	}
+	return pairsMap.get(target) as ComponentType<T>;
 }
 
-export const defineRelation = 
-    <T extends Schema>(schema: T = {} as T, options?: RelationOptions): RelationType<T> => {
-        const pairsMap = new Map();
-        const relation = function (target: number | string) {
-            if (target === undefined) throw Error("Relation target is undefined")
-            if (target === '*') target = Wildcard
-            return createOrGetRelationComponent<T>(relation, schema, pairsMap, target)
-        }
-        defineHiddenProperty(relation, $pairsMap, pairsMap)
-        defineHiddenProperty(relation, $schema, schema)
-        defineHiddenProperty(relation, $exclusiveRelation, options && options.exclusive)
-        defineHiddenProperty(relation, $autoRemoveSubject, options && options.autoRemoveSubject)
-        defineHiddenProperty(relation, $onTargetRemoved, options ? options.onTargetRemoved : undefined)
-        return relation as RelationType<T>
-    }
-
-export const Pair = <T extends Schema>(relation: RelationType<T>, target: number | string): ComponentType<T> => {
-    if (relation === undefined) throw Error("Relation is undefined")
-    if (target === undefined) throw Error("Relation target is undefined")
-    if (target === '*') target = Wildcard
-
-    const pairsMap = (relation as RelationType<T>)[$pairsMap]
-    const schema = (relation as RelationType<T>)[$schema] as T
-
-    return createOrGetRelationComponent<T>(relation, schema, pairsMap, target)
+export const defineRelation = <T extends Schema>(
+	schema: T = {} as T,
+	options?: RelationOptions
+): RelationType<T> => {
+	const pairsMap = new Map();
+	const relation = function (target: RelationTarget) {
+		if (target === undefined) throw Error('Relation target is undefined');
+		if (target === '*') target = Wildcard;
+		return createOrGetRelationComponent<T>(relation, schema, pairsMap, target);
+	};
+	defineHiddenProperty(relation, $pairsMap, pairsMap);
+	defineHiddenProperty(relation, $schema, schema);
+	defineHiddenProperty(relation, $exclusiveRelation, options && options.exclusive);
+	defineHiddenProperty(relation, $autoRemoveSubject, options && options.autoRemoveSubject);
+	defineHiddenProperty(relation, $onTargetRemoved, options ? options.onTargetRemoved : undefined);
+	return relation as RelationType<T>;
 };
 
-export const Wildcard: RelationType<any> | string = defineRelation()
-export const IsA: RelationType<any> = defineRelation()
+export const Pair = <T extends Schema>(
+	relation: RelationType<T>,
+	target: RelationTarget
+): ComponentType<T> => {
+	if (relation === undefined) throw Error('Relation is undefined');
+	if (target === undefined) throw Error('Relation target is undefined');
+	if (target === '*') target = Wildcard;
 
-export const getRelationTargets = (world: World, relation:RelationType<any>, eid: number) => {
-    const components = getEntityComponents(world, eid);
-    const targets = []
-    for (const c of components) {
-        if (c[$relation] === relation && c[$pairTarget] !== Wildcard) targets.push(c[$pairTarget])
-    }
-    return targets
-}
+	const pairsMap = (relation as RelationType<T>)[$pairsMap];
+	const schema = (relation as RelationType<T>)[$schema] as T;
+
+	return createOrGetRelationComponent<T>(relation, schema, pairsMap, target);
+};
+
+export const Wildcard: RelationType<any> | string = defineRelation();
+export const IsA: RelationType<any> = defineRelation();
+
+export const getRelationTargets = (world: World, relation: RelationType<any>, eid: number) => {
+	const components = getEntityComponents(world, eid);
+	const targets = [];
+	for (const c of components) {
+		if (c[$relation] === relation && c[$pairTarget] !== Wildcard) {
+			if (c[$pairTarget] instanceof Object) {
+				const eid = c[$pairTarget][$worldToPrefab].get(world);
+				targets.push(eid);
+			} else {
+				targets.push(c[$pairTarget]);
+			}
+		}
+	}
+	return targets;
+};

--- a/packages/classic/src/relation/types.ts
+++ b/packages/classic/src/relation/types.ts
@@ -1,21 +1,24 @@
-import { $schema } from "../component/symbols"
-import { ComponentType } from "../component/types"
-import { Schema } from "../storage/types"
-import { World } from "../world/types"
-import { $autoRemoveSubject, $exclusiveRelation, $onTargetRemoved, $pairsMap } from "./symbols"
+import { $schema } from '../component/symbols';
+import { ComponentType } from '../component/types';
+import { PrefabToken } from '../prefab/types';
+import { Schema } from '../storage/types';
+import { World } from '../world/types';
+import { $autoRemoveSubject, $exclusiveRelation, $onTargetRemoved, $pairsMap } from './symbols';
 
-export type OnTargetRemovedCallback = (world: World, subject: number, target: number) => void
+export type OnTargetRemovedCallback = (world: World, subject: number, target: number) => void;
 
 export type RelationOptions = {
-    exclusive?: boolean
-    autoRemoveSubject?: boolean
-    onTargetRemoved?: OnTargetRemovedCallback
-}
+	exclusive?: boolean;
+	autoRemoveSubject?: boolean;
+	onTargetRemoved?: OnTargetRemovedCallback;
+};
+
+export type RelationTarget = number | string | PrefabToken;
 
 export type RelationType<T extends Schema> = T & {
-    [$pairsMap]: Map<number | string, ComponentType<T>>
-    [$schema]: Schema
-    [$exclusiveRelation]: boolean
-    [$autoRemoveSubject]: boolean
-    [$onTargetRemoved]: OnTargetRemovedCallback
-} & ((target: string | number) => ComponentType<T>)
+	[$pairsMap]: Map<number | string, ComponentType<T>>;
+	[$schema]: Schema;
+	[$exclusiveRelation]: boolean;
+	[$autoRemoveSubject]: boolean;
+	[$onTargetRemoved]: OnTargetRemovedCallback;
+} & ((target: RelationTarget) => ComponentType<T>);

--- a/packages/classic/test/integration/Prefab.test.ts
+++ b/packages/classic/test/integration/Prefab.test.ts
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import {
+	IsA,
+	Types,
+	addComponent,
+	addEntity,
+	createWorld,
+	defineComponent,
+	definePrefab,
+	hasComponent,
+	registerPrefab,
+} from '../../src';
+import { describe, test } from 'vitest';
+
+describe('Prefab Integration Tests', () => {
+	test('should reference a prefab and inherit from it', () => {
+		const world = createWorld();
+
+		const Position = defineComponent({
+			x: Types.f32,
+			y: Types.f32,
+		});
+
+		const Sprite = {
+			url: {} as Record<number, string>,
+		};
+
+		const Player = definePrefab([Position, Sprite]);
+
+		{
+			const eid = registerPrefab(world, Player);
+			Position.x[eid] = 10;
+			Position.y[eid] = 10;
+			Sprite.url[eid] = 'assets/player.png';
+		}
+
+		const eid = addEntity(world);
+		addComponent(world, IsA(Player), eid);
+
+		assert(hasComponent(world, Position, eid));
+		assert(hasComponent(world, Sprite, eid));
+
+		assert(Position.x[eid] === 10);
+		assert(Position.y[eid] === 10);
+		assert(Sprite.url[eid] === 'assets/player.png');
+	});
+});


### PR DESCRIPTION
Unfortunately there are several formatting changes included as prettier took over a bunch of unformatted code.

The gist of the changes is the following:
- `definePrefab` returns a `PrefabToken`, containing a list of components and a `Map<World, eid>`
- `registerPrefab` assigns an eid to the prefab by internally calling `addPrefab`, and pairs the eid with the world in the `PrefabToken` world -> eid map
- Calling `IsA` (or any other relation) on a `PrefabToken` stores it in the relation's `$pairsMap` and the component's `$pairTarget`, as it would for an eid
- `getRelationTargets` checks if `$pairTarget` is a `PrefabToken` and converts it to an eid, using the world -> eid map of `PrefabToken`

See the included integration test (`Prefab.test.ts`) for usage. 