### PR TITLE
Fixes falsey check for exclusive relations and adds unit test

### DIFF
--- a/packages/classic/src/component/Component.ts
+++ b/packages/classic/src/component/Component.ts
@@ -183,7 +183,7 @@ export const addComponent = (world: World, component: Component, eid: number, re
 		// if it's an exclusive relation, remove the old target
 		if (relation[$exclusiveRelation] === true && target !== Wildcard) {
 			const oldTarget = getRelationTargets(world, relation, eid)[0];
-			if (oldTarget && oldTarget !== target) {
+			if (oldTarget >= 0 && oldTarget !== target) {
 				removeComponent(world, relation(oldTarget), eid);
 			}
 		}

--- a/packages/classic/src/component/Component.ts
+++ b/packages/classic/src/component/Component.ts
@@ -183,7 +183,7 @@ export const addComponent = (world: World, component: Component, eid: number, re
 		// if it's an exclusive relation, remove the old target
 		if (relation[$exclusiveRelation] === true && target !== Wildcard) {
 			const oldTarget = getRelationTargets(world, relation, eid)[0];
-			if (oldTarget >= 0 && oldTarget !== target) {
+			if (oldTarget !== undefined && oldTarget !== null && oldTarget !== target) {
 				removeComponent(world, relation(oldTarget), eid);
 			}
 		}

--- a/packages/classic/test/unit/Relation.test.ts
+++ b/packages/classic/test/unit/Relation.test.ts
@@ -6,12 +6,31 @@ import {
 	createWorld,
 	defineRelation,
 	entityExists,
+	getRelationTargets,
 	hasComponent,
 	removeEntity,
 } from '../../src';
 import { describe, test } from 'vitest';
 
 describe('Relation Unit Tests', () => {
+	// this test only works if the player eid is 0, so it needs to be first
+	test('should maintain exclusive relations for eid 0', () => {
+		const world = createWorld();
+
+		const player = addEntity(world); // 0
+		const guard = addEntity(world); // 1
+		const goblin = addEntity(world); // 2
+
+		const Targeting = defineRelation({ exclusive: true });
+
+		addComponent(world, Targeting(player), goblin);
+		addComponent(world, Targeting(guard), goblin);
+
+		assert(getRelationTargets(world, Targeting, goblin).length === 1); 
+		assert(hasComponent(world, Targeting(player), goblin) === false);
+		assert(hasComponent(world, Targeting(guard), goblin) === true);
+	});
+
 	test('should auto remove subject', () => {
 		const world = createWorld();
 
@@ -93,7 +112,6 @@ describe('Relation Unit Tests', () => {
 		const rat = addEntity(world);
 		const goblin = addEntity(world);
 
-		addComponent(world, Targeting(rat), hero);
 		addComponent(world, Targeting(goblin), hero);
 
 		assert(hasComponent(world, Targeting(rat), hero) === false);


### PR DESCRIPTION
note: I'd like to move the newly added test to the end of the test file, but I don't know how to reset the eid count for "addEntity". If the new test is added as is to the bottom the "player" eid would be 14 and the test would pass without the fix