### PR TITLE
Fix v0.4 docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-:warning: [v0.4](https://github.com/NateTheGreatt/bitECS/blob/next-simple) coming soon! Read the [docs here](/docs/Intro.md)
+:warning: [v0.4](https://github.com/NateTheGreatt/bitECS/blob/next-simple) coming soon! Read the [docs here](https://github.com/NateTheGreatt/bitECS/blob/next-simple/docs/Intro.md)
 
 
 <h1 align="center">


### PR DESCRIPTION
The new docs are only on the new `next-simple` branch, so the link will need to point to that (for now).