### PR TITLE
Update readme to reference Enchantment Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ requestAnimationFrame(function animate() {
 
 ## 🔌 Used by
 
-- [iR Engine](https://github.com/ir-engine/ir-engine)
+- [Enchantment Engine](https://github.com/EnchantmentEngine/EnchantmentEngine)
 - [Third Room](https://github.com/thirdroom/thirdroom)
 - [Hubs](https://github.com/Hubs-Foundation/hubs)
 


### PR DESCRIPTION
https://github.com/EnchantmentEngine/EnchantmentEngine is the official fork of iR Engine after the engine was archived. This reflects the new repository in the readme.